### PR TITLE
Responses might have some payload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: php
 
 php:
-  - 5.4
   - 5.5
+  - 5.6
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
 
 

--- a/Fliglio/Http/Exceptions/HttpStatusException.php
+++ b/Fliglio/Http/Exceptions/HttpStatusException.php
@@ -7,6 +7,8 @@ class HttpStatusException extends \Exception {
 	protected static $status;
 
 	private $errorInfo;
+	
+	private $data;
 
 	public function getStatusCode() {
 		return static::$status;
@@ -19,4 +21,12 @@ class HttpStatusException extends \Exception {
 		return $this;
 	}
 
+	public function getData() {
+		return $this->data;
+	}
+
+	public function setData($data) {
+		$this->data = $data;
+		return $this;
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1.0"

--- a/test/HttpStatusExceptionTest.php
+++ b/test/HttpStatusExceptionTest.php
@@ -35,5 +35,34 @@ class BodyTest extends \PHPUnit_Framework_TestCase {
 			$this->assertEquals($status, $obj->getStatusCode());
 		}
 	}
+	
+	public function testDataPayload() {
+		// given
+		try {
+			
+			// when
+			throw (new \Fliglio\Http\Exceptions\ConflictException)
+				->setData($data = ['foo' => 'bar']);
+		} catch (Fliglio\Http\Exceptions\ConflictException $e) {
+			
+			//then
+			$this->assertEquals($data, $e->getData());
+		}
+	}
+	
+	public function testErrorPayload() {
+		// given
+		try {
+
+			// when
+			throw (new \Fliglio\Http\Exceptions\ConflictException)
+				->setErrorInfo($error = 'You got an error!');
+		} catch (Fliglio\Http\Exceptions\ConflictException $e) {
+
+			//then
+			$this->assertEquals($error, $e->getErrorInfo());
+		}
+		
+	}
 
 }

--- a/test/HttpStatusExceptionTest.php
+++ b/test/HttpStatusExceptionTest.php
@@ -41,9 +41,9 @@ class BodyTest extends \PHPUnit_Framework_TestCase {
 		try {
 			
 			// when
-			throw (new \Fliglio\Http\Exceptions\ConflictException)
+			throw (new ConflictException)
 				->setData($data = ['foo' => 'bar']);
-		} catch (Fliglio\Http\Exceptions\ConflictException $e) {
+		} catch (\ConflictException $e) {
 			
 			//then
 			$this->assertEquals($data, $e->getData());
@@ -55,9 +55,9 @@ class BodyTest extends \PHPUnit_Framework_TestCase {
 		try {
 
 			// when
-			throw (new \Fliglio\Http\Exceptions\ConflictException)
+			throw (new ConflictException)
 				->setErrorInfo($error = 'You got an error!');
-		} catch (Fliglio\Http\Exceptions\ConflictException $e) {
+		} catch (ConflictException $e) {
 
 			//then
 			$this->assertEquals($error, $e->getErrorInfo());

--- a/test/HttpStatusExceptionTest.php
+++ b/test/HttpStatusExceptionTest.php
@@ -35,21 +35,22 @@ class BodyTest extends \PHPUnit_Framework_TestCase {
 			$this->assertEquals($status, $obj->getStatusCode());
 		}
 	}
-	
+
 	public function testDataPayload() {
 		// given
 		try {
-			
+
 			// when
 			throw (new ConflictException)
 				->setData($data = ['foo' => 'bar']);
-		} catch (\ConflictException $e) {
-			
+
+		} catch (ConflictException $e) {
+
 			//then
 			$this->assertEquals($data, $e->getData());
 		}
 	}
-	
+
 	public function testErrorPayload() {
 		// given
 		try {
@@ -62,7 +63,7 @@ class BodyTest extends \PHPUnit_Framework_TestCase {
 			//then
 			$this->assertEquals($error, $e->getErrorInfo());
 		}
-		
+
 	}
 
 }


### PR DESCRIPTION
Proper REST std (https://tools.ietf.org/html/rfc7231#section-6.5.8) says 409s should have a payload that indicates what is in conflict so caller can handle. Adding the ability for exception handler to capture a payload, in addition to error, and bubble that up. 